### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build
 
+permissions: {}
+
 on:
   pull_request:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/CloudTooling/dev-buildbox/security/code-scanning/3](https://github.com/CloudTooling/dev-buildbox/security/code-scanning/3)

To fix the problem, restrict the GITHUB_TOKEN permissions granted to this workflow (and all jobs by default) by adding a `permissions` block. The block should be placed at the root level, immediately under the workflow `name:` or before `jobs:`, or at least in the "Build-results" job since that's where the error was highlighted. The conservative/minimal setting for jobs that do not require repo access is `permissions: {}` (i.e., no permissions), or `permissions: read-all` if some readonly access may be required (but in this case, `{}` is safe). If all jobs in the workflow are similarly safe, it is best to add it at the workflow root so all jobs inherit strict permissions. No other code modifications or imports are needed—just the addition of the correct YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
