### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 permissions: {}
 


### PR DESCRIPTION
Potential fix for [https://github.com/CloudTooling/dev-buildbox/security/code-scanning/2](https://github.com/CloudTooling/dev-buildbox/security/code-scanning/2)

To fix this problem, add an explicit `permissions` key at the top/root of the workflow file, specifying minimal required permissions for all jobs (unless some jobs need broader permissions, which does not appear to be the case from the code provided). The minimal starting point recommended by CodeQL is `contents: read`, which will suffice for most build and publish workflows that do not need to push code, create issues, or otherwise write to the repository via the GITHUB_TOKEN. Insert the following block directly under the `name: Build` line and before the `on:` block in `.github/workflows/build.yml`. No changes to imports, jobs, or steps are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
