### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 permissions: {}
 


### PR DESCRIPTION
Potential fix for [https://github.com/CloudTooling/dev-buildbox/security/code-scanning/1](https://github.com/CloudTooling/dev-buildbox/security/code-scanning/1)

To fix the problem, add a `permissions` block to restrict the `GITHUB_TOKEN` permissions. The best way is to set the permissions at the top-level of the workflow so they apply to all jobs by default. Based on the workflow, the jobs interact only with the repository code and external Docker registries via secrets, so the minimal required permission is `contents: read`. There is no evidence that the jobs require other elevated permissions (such as `issues: write` or `pull-requests: write`). The change should be made at the very top of .github/workflows/build.yml after the `name` field and before the `on` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
